### PR TITLE
Filter out non-string messages and fix messaging loop

### DIFF
--- a/src/components/School/Python_Basics.vue
+++ b/src/components/School/Python_Basics.vue
@@ -28,10 +28,9 @@ export default {
     // Listen to message from iframe element
     window.addEventListener('message', function (msg) {
       var message = msg.data
-      var locationHash = message.substring(message.indexOf('#'))
-      // console.log(locationHash)
-
+      if (typeof message !== 'string') return
       if (message.startsWith('locHash:')) {
+        var locationHash = message.substring(message.indexOf('#'))
         var newurl = window.location.protocol + '//' + window.location.host + window.location.pathname + locationHash
         window.history.pushState({ path: newurl }, '', newurl)
       }
@@ -43,7 +42,7 @@ export default {
       var hash = window.location.hash
 
       if (hash) {
-        document.getElementById('myIframe').contentWindow.postMessage(hash, '*')
+        document.getElementById('myIframe').contentWindow.postMessage(`parentHash:${hash}`, '*')
         console.log(hash)
       } else {
         console.log('No hash!')

--- a/static/iFrame.html
+++ b/static/iFrame.html
@@ -326,9 +326,13 @@ bindEvent(window, 'hashchange', function () {
 
 // Listen to message from Parent
 bindEvent(window, 'message', function (e) {
-  var hashobj = e.data;
-  var hashstr = hashobj.replace("_", "-");
-  window.location.hash = hashstr;
+  var message = e.data;
+  if (typeof message !== 'string') return
+  if (message.startsWith('parentHash:')) {
+    var locationHash = message.substring(message.indexOf('#'))
+    var hashstr = locationHash.replace("_", "-");
+    window.location.hash = hashstr;
+  } 
 });
 </script>
 <hr />


### PR DESCRIPTION
Indeed, in iFrame.html, the handler for message events must react only on appropriate messages, and not on every messages (it receives its own messages and whatnot).
It's the exact same problem we've seen earlier on the parent. It's the whole point of prepending a message with something which tells you what's the point and the origin of that message, and then how to react to it.

Have fun :)